### PR TITLE
use `EnGlyphText` subclass for demo

### DIFF
--- a/src/textual_englyph/englyph.py
+++ b/src/textual_englyph/englyph.py
@@ -2,8 +2,10 @@
 
 from rich.console import RenderableType
 
+from rich.text import Text
 from textual.strip import Strip
 from textual.widget import Widget
+
 
 class EnGlyph(Widget, inherit_bindings=False):
     """
@@ -37,7 +39,7 @@ class EnGlyph(Widget, inherit_bindings=False):
         self.pips = pips
         self._predicate = self._preprocess(renderable)
 
-    def on_mount(self):
+    def on_mount(self) -> None:
         self._process()
 
     def get_content_width(self, container=None, viewport=None):
@@ -74,8 +76,16 @@ class EnGlyph(Widget, inherit_bindings=False):
         if isinstance(rhs, float):
             pass
 
+    def _convert_markup(self, renderable: RenderableType | str) -> Text:
+        if self.markup:
+            return Text.from_markup(renderable)
+        return Text(renderable)
+
     def __str__(self) -> str:
+        renderable = self._convert_markup(self._predicate)
+        self._process()
         output = [strip.text for strip in self._slate]
+        self._renderable = renderable
         return "\n".join(output)
 
     def _preprocess(self) -> None:

--- a/src/textual_englyph/main_demo.py
+++ b/src/textual_englyph/main_demo.py
@@ -3,7 +3,7 @@
 from textual.app import App, ComposeResult
 from textual.containers import Vertical, Horizontal
 from textual.widgets import Header, Footer, Button, TextArea
-from textual_englyph import EnGlyph
+from textual_englyph import EnGlyphText
 
 # pylint: disable=R0801
 CONTENT = '''\
@@ -19,7 +19,7 @@ class Test(App):
     """
 
     def compose(self) -> ComposeResult:
-        yield EnGlyph("EnGlyph [blue]Textual!")
+        yield EnGlyphText("EnGlyph [blue]Textual!")
 
 if __name__ == "__main__":
     app = Test()
@@ -55,12 +55,12 @@ class MainDemo(App):
         yield Footer()
         with Vertical():
             with Horizontal(id="choice"):
-                yield Button(str(EnGlyph("PREV")))
-                yield EnGlyph("Examples")
-                yield Button(str(EnGlyph("NEXT")))
+                yield Button(str(EnGlyphText("PREV")))
+                yield EnGlyphText("Examples")
+                yield Button(str(EnGlyphText("NEXT")))
             with Horizontal():
                 yield self.code
-                yield EnGlyph("EnGlyph [blue]Textual!")
+                yield EnGlyphText("EnGlyph [blue]Textual!")
 
 
 def main_demo():

--- a/src/textual_englyph/main_demo.py
+++ b/src/textual_englyph/main_demo.py
@@ -12,14 +12,14 @@ from textual_englyph import EnGlyph
 
 class Test(App):
     DEFAULT_CSS = """
-    EnGlyph {
+    EnGlyphText {
         color: green;
         text-style: underline;
         }
     """
 
     def compose(self) -> ComposeResult:
-        yield EnGlyphText("EnGlyph [blue]Textual!")
+        yield EnGlyphText("EnGlyph [blue]Textual!", text_size="large")
 
 if __name__ == "__main__":
     app = Test()
@@ -31,16 +31,21 @@ class MainDemo(App):
     """Test CSS and console markup styling the basic englyph use case"""
 
     TITLE = "EnGlyph_Demo"
-    DEFAULT_CSS = """
+    DEFAULT_CSS = """\
     TextArea {
         min-height: 80%;
-        width: 57;
-        max-width: 57;
+        max-width: 80;
     }
     EnGlyph {
         color: green;
-        text-style: underline;
+        width: auto;
+        content-align-vertical: middle;
+        padding: 1 2;
+        &.title {
+            text-style: underline;
+            align: center middle;
         }
+    }
     #choice {
         height: 10;
         align: center top;
@@ -55,12 +60,16 @@ class MainDemo(App):
         yield Footer()
         with Vertical():
             with Horizontal(id="choice"):
-                yield Button(str(EnGlyphText("PREV")))
-                yield EnGlyphText("Examples")
-                yield Button(str(EnGlyphText("NEXT")))
+                yield Button(str(EnGlyphText("PREV", text_size="medium")))
+                yield EnGlyphText("Examples", text_size="medium")
+                yield Button(str(EnGlyphText("NEXT", text_size="medium")))
             with Horizontal():
                 yield self.code
-                yield EnGlyphText("EnGlyph [blue]Textual!")
+                yield EnGlyphText(
+                    "EnGlyph [blue]Textual![/blue]",
+                    text_size="large",
+                    classes="title",
+                )
 
 
 def main_demo():


### PR DESCRIPTION
As discussed on Discord this is a fix for the demo. It updates the classes to reflect the new naming structure.

The demo is not behaving as the original though. See image below:

![image](https://github.com/user-attachments/assets/9b6f0b4e-72de-4bc6-931f-9af35d3ad384)

Those buttons before displayed the text fully enlarged.

---

On a side note I would recommend to change the demo entry point to `textual-englyph`. 

That way you can just run `uvx textual-englyph` or `pipx run textual-englyph` without setting an entry point.

